### PR TITLE
feat(UuidCommand): Add '--type' argument to support ULID generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation "com.github.ajalt.clikt:clikt:5.0.3"
     implementation "com.github.ajalt.clikt:clikt-markdown:5.0.3"
     implementation "io.github.g0dkar:qrcode-kotlin:4.4.1"
+    implementation "com.aallam.ulid:ulid-kotlin:1.3.0"
 }
 
 test {

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,6 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.aallam.ulid:ulid-kotlin-jvm:1.3.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.aallam.ulid:ulid-kotlin:1.3.0=compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 com.github.ajalt.clikt:clikt-core-jvm:5.0.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.ajalt.clikt:clikt-core:5.0.3=compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 com.github.ajalt.clikt:clikt-jvm:5.0.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
@@ -41,7 +43,9 @@ org.jetbrains.kotlin:kotlin-scripting-common:2.1.20=kotlinBuildToolsApiClasspath
 org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:2.1.20=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
 org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:2.1.20=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
 org.jetbrains.kotlin:kotlin-scripting-jvm:2.1.20=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
-org.jetbrains.kotlin:kotlin-stdlib-common:2.1.20=implementationDependenciesMetadata,testImplementationDependenciesMetadata
+org.jetbrains.kotlin:kotlin-stdlib-common:2.1.20=compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.jetbrains.kotlin:kotlin-stdlib:2.1.20=apiDependenciesMetadata,compileClasspath,implementationDependenciesMetadata,kotlinBuildToolsApiClasspath,kotlinCompilerClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,kotlinKlibCommonizerClasspath,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 org.jetbrains.kotlin:kotlin-test-junit5:2.1.20=testCompileClasspath,testRuntimeClasspath
 org.jetbrains.kotlin:kotlin-test:2.1.20=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
@@ -50,6 +54,9 @@ org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0=compileClasspath,runtimeClass
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0=kotlinBuildToolsApiClasspath,kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.9.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0=compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.4.0=runtimeClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-datetime:0.4.0=implementationDependenciesMetadata,runtimeClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.3.2=implementationDependenciesMetadata,testImplementationDependenciesMetadata
 org.jetbrains:annotations:13.0=kotlinBuildToolsApiClasspath,kotlinCompilerClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,kotlinKlibCommonizerClasspath
 org.jetbrains:annotations:23.0.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.jetbrains:markdown-jvm:0.7.3=runtimeClasspath,testRuntimeClasspath

--- a/src/main/kotlin/features/uuid/UuidCommand.kt
+++ b/src/main/kotlin/features/uuid/UuidCommand.kt
@@ -5,8 +5,11 @@ import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.validate
+import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.int
 import org.jack.features.uuid.services.UuidService
+
+enum class UuidType { UUID, ULID }
 
 const val UUID_COMMAND_NAME = "uuid"
 const val UUID_HELP = "Generate a random unique identifier"
@@ -14,6 +17,9 @@ const val UUID_COUNT_NAME = "--count"
 const val UUID_COUNT_NAME_SHORT = "-c"
 const val UUID_COUNT_HELP = "Number of unique identifiers"
 const val UUID_COUNT_MUST_BE_POSITIVE_INTEGER = "Must be a positive integer"
+const val UUID_TYPE_NAME = "--type"
+const val UUID_TYPE_NAME_SHORT = "-t"
+const val UUID_TYPE_HELP = "The type of the unique identifier."
 
 class UuidCommand(private val uuidService: UuidService) : CliktCommand(name = UUID_COMMAND_NAME) {
     val count by option(
@@ -25,11 +31,20 @@ class UuidCommand(private val uuidService: UuidService) : CliktCommand(name = UU
         }
     }
 
+    val type: UuidType by option(UUID_TYPE_NAME, UUID_TYPE_NAME_SHORT,
+        help = UUID_TYPE_HELP)
+        .enum<UuidType>()
+        .default(UuidType.UUID)
+
     override fun help(context: Context) = UUID_HELP
 
     override fun run() {
         repeat(times = count) {
-            echo(uuidService.randomUuid())
+            val uniqueIdentifier = when (type) {
+                UuidType.ULID -> uuidService.randomUlid()
+                UuidType.UUID -> uuidService.randomUuid()
+            }
+            echo(uniqueIdentifier)
         }
     }
 }

--- a/src/main/kotlin/features/uuid/UuidCommand.kt
+++ b/src/main/kotlin/features/uuid/UuidCommand.kt
@@ -19,7 +19,7 @@ const val UUID_COUNT_HELP = "Number of unique identifiers"
 const val UUID_COUNT_MUST_BE_POSITIVE_INTEGER = "Must be a positive integer"
 const val UUID_TYPE_NAME = "--type"
 const val UUID_TYPE_NAME_SHORT = "-t"
-const val UUID_TYPE_HELP = "The type of the unique identifier."
+const val UUID_TYPE_HELP = "The type of the unique identifier"
 
 class UuidCommand(private val uuidService: UuidService) : CliktCommand(name = UUID_COMMAND_NAME) {
     val count by option(
@@ -39,12 +39,14 @@ class UuidCommand(private val uuidService: UuidService) : CliktCommand(name = UU
     override fun help(context: Context) = UUID_HELP
 
     override fun run() {
+        val getRandomId = when (type) {
+            UuidType.UUID -> uuidService::randomUuid
+            UuidType.ULID -> uuidService::randomUlid
+        }
+
         repeat(times = count) {
-            val uniqueIdentifier = when (type) {
-                UuidType.ULID -> uuidService.randomUlid()
-                UuidType.UUID -> uuidService.randomUuid()
-            }
-            echo(uniqueIdentifier)
+
+            echo(getRandomId())
         }
     }
 }

--- a/src/main/kotlin/features/uuid/services/UuidService.kt
+++ b/src/main/kotlin/features/uuid/services/UuidService.kt
@@ -4,4 +4,5 @@ import java.util.*
 
 interface UuidService {
     fun randomUuid(): UUID
+    fun randomUlid(): String
 }

--- a/src/main/kotlin/features/uuid/services/impl/UuidServiceImpl.kt
+++ b/src/main/kotlin/features/uuid/services/impl/UuidServiceImpl.kt
@@ -1,10 +1,15 @@
 package org.jack.features.uuid.services.impl
 
 import org.jack.features.uuid.services.UuidService
+import ulid.ULID
 import java.util.*
 
 class UuidServiceImpl : UuidService {
     override fun randomUuid(): UUID {
         return UUID.randomUUID()
+    }
+
+    override fun randomUlid(): String {
+        return ULID.randomULID()
     }
 }

--- a/src/test/kotlin/commands/UuidCommandTest.kt
+++ b/src/test/kotlin/commands/UuidCommandTest.kt
@@ -89,6 +89,16 @@ class UuidCommandTest {
     }
 
     @Test
+    fun `when '--count' argument passed with value 25 expect 25 ulids`() {
+        val count = 25
+
+        val result = assertDoesNotThrow { command.test("--type ulid --count $count") }
+
+        val ulidCount = result.stdout.split("\n").filter { it.isNotEmpty() }.count()
+        assertEquals(count, ulidCount)
+    }
+
+    @Test
     fun `when '--type' argument passed with value 'uuid' expect a valid UUID`() {
         val result = command.test("--type uuid").stdout
         val trimmedResult = result.trim()

--- a/src/test/kotlin/commands/UuidCommandTest.kt
+++ b/src/test/kotlin/commands/UuidCommandTest.kt
@@ -2,9 +2,12 @@ package commands
 
 import com.github.ajalt.clikt.testing.test
 import org.jack.features.uuid.UuidCommand
+import org.jack.features.uuid.UuidType
 import org.jack.features.uuid.services.impl.UuidServiceImpl
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import ulid.ULID
+import java.util.UUID
 import kotlin.test.assertEquals
 
 class UuidCommandTest {
@@ -62,5 +65,42 @@ class UuidCommandTest {
         val result = command.test("-c -1")
 
         assert(result.stderr.isNotEmpty())
+    }
+
+    @Test
+    fun `when no '--type' argument passed 'type' member defaults to UUID`() {
+        val result = command.test().run { command }
+
+        assert(result.type == UuidType.UUID)
+    }
+
+    @Test
+    fun `when '--type' argument passed with value 'uuid' type option is set to correct enum member`() {
+        val result = command.test("--type uuid").run { command }
+
+        assert(result.type == UuidType.UUID)
+    }
+
+    @Test
+    fun `when '--type' argument passed with value 'ulid' type option is set to correct enum member`() {
+        val result = command.test("--type ulid").run { command }
+
+        assert(result.type == UuidType.ULID)
+    }
+
+    @Test
+    fun `when '--type' argument passed with value 'uuid' expect a valid UUID`() {
+        val result = command.test("--type uuid").stdout
+        val trimmedResult = result.trim()
+
+        assertDoesNotThrow {  UUID.fromString(trimmedResult)}
+    }
+
+    @Test
+    fun `when '--type' argument passed with value 'ulid' expect a valid ULID`() {
+        val result = command.test("--type ulid").stdout
+        val trimmedResult = result.trim()
+
+        assertDoesNotThrow {  ULID.parseULID(trimmedResult)}
     }
 }


### PR DESCRIPTION
### Description
This PR adds a support for a new argument in the `jack uuid` command called `--type` which sets the type of the unique identifier and adds support for [ULID](https://github.com/ulid/spec) unique identifier type.

It leaves the original `UUID` format to be the default but also support the type `uuid` to be passed for compatibility. 

### Testing scenario
Besides running the newly added unit tests you can execute this scenario:

1. Build the binaries and add `jack` to your $PATH variable. 
2. Run `jack uuid` to verify that the old implementation is not broken or changed.
3. Run `jack uuid -t ulid` to verify the new `ULID` output.
4. Run `jack uuid -t uuid` to verify the type argument support for the original `uuid` output.
5. Run `jack uuid -t ulid` to verify that the `count` argument works with the new `type` argument.