### PR TITLE
feat: add a UUID/ULID validation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@ A versatile CLI tool for common developer tasks.
 
 ## Usage
 
-### UUID Generation
+### UUIDs
+#### UUID Generation
 Generate one or more UUIDs or ULIDs.
 ```bash
 jack uuid
 jack uuid --count 5 --type ULID
+```
+
+#### Validate UUID/ULID
+Validate a single UUID or ULID value. Use `-v` or `--validate` with `--type` to specify the identifier type.
+```bash
+jack uuid -v 3fa85f64-5717-4562-b3fc-2c963f66afa6
+
+jack uuid --type ULID --validate 01ARYZ6S41TSV4RRFFQ69G5FAV
 ```
 
 ### Lorem Ipsum
@@ -91,6 +100,7 @@ Download the latest archive from the [releases page](https://github.com/dimeskig
 
 ## Features
 - **UUID/ULID**: Bulk generation of unique identifiers.
+- **UUID/ULID Validating**: Validating a provided UUID/ULID.
 - **Lorem Ipsum**: Customizable placeholder text.
 - **QR Codes**: PNG generation with custom colors.
 - **Hashing**: MD5, SHA1, SHA256, SHA512 support.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ A versatile CLI tool for common developer tasks.
 
 ### UUIDs
 #### UUID Generation
-<<<<<<< HEAD
 Generate one or more UUIDs or ULIDs using the `generate` subcommand. 
-=======
-Generate one or more UUIDs or ULIDs.
->>>>>>> 98a7bd8f7a6ddcda39cc31c425c1fae9d893e5b2
 ```bash
 jack uuid generate
 jack uuid generate --count 5 --type ULID

--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ jack uuid validate <uuid>
 jack uuid validate --type ULID <ulid>
 ```
 
-#### Validate UUID/ULID
-Validate a single UUID or ULID value. Use `-v` or `--validate` with `--type` to specify the identifier type.
-```bash
-jack uuid -v 3fa85f64-5717-4562-b3fc-2c963f66afa6
-
-jack uuid --type ULID --validate 01ARYZ6S41TSV4RRFFQ69G5FAV
-```
-
 ### Lorem Ipsum
 Generate placeholder text.
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ A versatile CLI tool for common developer tasks.
 
 ### UUIDs
 #### UUID Generation
-Generate one or more UUIDs or ULIDs.
+Generate one or more UUIDs or ULIDs using the `generate` subcommand. 
 ```bash
-jack uuid
-jack uuid --count 5 --type ULID
+jack uuid generate
+jack uuid generate --count 5 --type ULID
 ```
 
 #### Validate UUID/ULID
-Validate a single UUID or ULID value. Use `-v` or `--validate` with `--type` to specify the identifier type.
+Validate a single UUID or ULID value using the `validate` subcommand.
 ```bash
-jack uuid -v 3fa85f64-5717-4562-b3fc-2c963f66afa6
+jack uuid validate <uuid>
 
-jack uuid --type ULID --validate 01ARYZ6S41TSV4RRFFQ69G5FAV
+jack uuid validate --type ULID <ulid>
 ```
 
 ### Lorem Ipsum
@@ -99,8 +99,7 @@ The executable will be located in `build/native/nativeCompile`.
 Download the latest archive from the [releases page](https://github.com/dimeskigj/jack-cli/releases), extract it, and add the `bin` folder to your `PATH`.
 
 ## Features
-- **UUID/ULID**: Bulk generation of unique identifiers.
-- **UUID/ULID Validating**: Validating a provided UUID/ULID.
+- **UUID/ULID**: Validation and bulk generation of unique identifiers.
 - **Lorem Ipsum**: Customizable placeholder text.
 - **QR Codes**: PNG generation with custom colors.
 - **Hashing**: MD5, SHA1, SHA256, SHA512 support.

--- a/src/main/kotlin/features/uuid/UuidCommand.kt
+++ b/src/main/kotlin/features/uuid/UuidCommand.kt
@@ -2,17 +2,15 @@ package org.jack.features.uuid
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.validate
-import com.github.ajalt.clikt.parameters.types.enum
-import com.github.ajalt.clikt.parameters.types.int
+import com.github.ajalt.clikt.core.subcommands
 import org.jack.features.uuid.services.UuidService
+import org.jack.features.uuid.subcommands.GenerateCommand
+import org.jack.features.uuid.subcommands.ValidateCommand
 
 enum class UuidType { UUID, ULID }
 
 const val UUID_COMMAND_NAME = "uuid"
-const val UUID_HELP = "Generate a random unique identifier"
+const val UUID_HELP = "Work with UUIDs and ULIDs"
 const val UUID_COUNT_NAME = "--count"
 const val UUID_COUNT_NAME_SHORT = "-c"
 const val UUID_COUNT_HELP = "Number of unique identifiers"
@@ -21,61 +19,21 @@ const val UUID_TYPE_NAME = "--type"
 const val UUID_TYPE_NAME_SHORT = "-t"
 const val UUID_TYPE_HELP = "The type of the unique identifier"
 const val DEFAULT_UUID_COUNT = 1
-const val UUID_VALIDATE_NAME = "--validate"
-const val UUID_VALIDATE_NAME_SHORT = "-v"
-const val UUID_VALIDATE_HELP = "Validate a UUID/ULID value provided as a paramter"
+const val UUID_GENERATE_COMMAND_NAME = "generate"
+const val UUID_GENERATE_HELP = "Generate random unique identifiers"
+const val UUID_VALIDATE_COMMAND_NAME = "validate"
+const val UUID_VALIDATE_HELP = "Validate a UUID/ULID value"
+const val UUID_VALUE_ARGUMENT_NAME = "value"
+const val UUID_VALUE_HELP = "The UUID/ULID value to validate"
 
 class UuidCommand(
     private val uuidService: UuidService,
 ) : CliktCommand(name = UUID_COMMAND_NAME) {
-    val count by option(
-        UUID_COUNT_NAME,
-        UUID_COUNT_NAME_SHORT,
-        help = UUID_COUNT_HELP,
-    ).int().default(DEFAULT_UUID_COUNT).validate {
-        require(it > 0) {
-            UUID_COUNT_MUST_BE_POSITIVE_INTEGER
-        }
-    }
-
-    val type: UuidType by option(
-        UUID_TYPE_NAME,
-        UUID_TYPE_NAME_SHORT,
-        help = UUID_TYPE_HELP,
-    ).enum<UuidType>().default(UuidType.UUID)
-
-    val validateValue by option(
-        UUID_VALIDATE_NAME,
-        UUID_VALIDATE_NAME_SHORT,
-        help = UUID_VALIDATE_HELP,
-    )
-
     override fun help(context: Context) = UUID_HELP
 
-    override fun run() {
-        if (validateValue != null) {
-            val value = validateValue!!
-            val isValid = when (type) {
-                UuidType.UUID -> uuidService.validateUuid(value)
-                UuidType.ULID -> uuidService.validateUlid(value)
-            }
-
-            if (isValid) {
-                echo("Status: Valid")
-            } else {
-                echo("Status: Invalid", err = true)
-            }
-
-            return
-        }
-        val getRandomId =
-            when (type) {
-                UuidType.UUID -> uuidService::randomUuid
-                UuidType.ULID -> uuidService::randomUlid
-            }
-
-        repeat(times = count) {
-            echo(getRandomId())
-        }
+    init {
+        subcommands(GenerateCommand(uuidService), ValidateCommand(uuidService))
     }
+
+    override fun run() = Unit
 }

--- a/src/main/kotlin/features/uuid/UuidCommand.kt
+++ b/src/main/kotlin/features/uuid/UuidCommand.kt
@@ -21,6 +21,9 @@ const val UUID_TYPE_NAME = "--type"
 const val UUID_TYPE_NAME_SHORT = "-t"
 const val UUID_TYPE_HELP = "The type of the unique identifier"
 const val DEFAULT_UUID_COUNT = 1
+const val UUID_VALIDATE_NAME = "--validate"
+const val UUID_VALIDATE_NAME_SHORT = "-v"
+const val UUID_VALIDATE_HELP = "Validate a UUID/ULID value provided as a paramter"
 
 class UuidCommand(
     private val uuidService: UuidService,
@@ -41,9 +44,30 @@ class UuidCommand(
         help = UUID_TYPE_HELP,
     ).enum<UuidType>().default(UuidType.UUID)
 
+    val validateValue by option(
+        UUID_VALIDATE_NAME,
+        UUID_VALIDATE_NAME_SHORT,
+        help = UUID_VALIDATE_HELP,
+    )
+
     override fun help(context: Context) = UUID_HELP
 
     override fun run() {
+        if (validateValue != null) {
+            val value = validateValue!!
+            val isValid = when (type) {
+                UuidType.UUID -> uuidService.validateUuid(value)
+                UuidType.ULID -> uuidService.validateUlid(value)
+            }
+
+            if (isValid) {
+                echo("Status: Valid")
+            } else {
+                echo("Status: Invalid", err = true)
+            }
+
+            return
+        }
         val getRandomId =
             when (type) {
                 UuidType.UUID -> uuidService::randomUuid

--- a/src/main/kotlin/features/uuid/services/UuidService.kt
+++ b/src/main/kotlin/features/uuid/services/UuidService.kt
@@ -6,4 +6,8 @@ interface UuidService {
     fun randomUuid(): UUID
 
     fun randomUlid(): String
+
+    fun validateUuid(value: String): Boolean
+
+    fun validateUlid(value: String): Boolean
 }

--- a/src/main/kotlin/features/uuid/services/impl/UuidServiceImpl.kt
+++ b/src/main/kotlin/features/uuid/services/impl/UuidServiceImpl.kt
@@ -8,4 +8,22 @@ class UuidServiceImpl : UuidService {
     override fun randomUuid(): UUID = UUID.randomUUID()
 
     override fun randomUlid(): String = ULID.randomULID()
+
+    override fun validateUuid(value: String): Boolean =
+        UUID_REGEX.matches(value.trim())
+
+    override fun validateUlid(value: String): Boolean =
+        ULID_REGEX.matches(value.trim())
+
+    companion object {
+        private val UUID_REGEX = Regex(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            RegexOption.IGNORE_CASE,
+        )
+
+        private val ULID_REGEX = Regex(
+            "^[0-9A-HJ-NP-TV-Z]{26}$",
+            RegexOption.IGNORE_CASE,
+        )
+    }
 }

--- a/src/main/kotlin/features/uuid/services/impl/UuidServiceImpl.kt
+++ b/src/main/kotlin/features/uuid/services/impl/UuidServiceImpl.kt
@@ -9,21 +9,21 @@ class UuidServiceImpl : UuidService {
 
     override fun randomUlid(): String = ULID.randomULID()
 
-    override fun validateUuid(value: String): Boolean =
-        UUID_REGEX.matches(value.trim())
+    override fun validateUuid(value: String): Boolean = UUID_REGEX.matches(value.trim())
 
-    override fun validateUlid(value: String): Boolean =
-        ULID_REGEX.matches(value.trim())
+    override fun validateUlid(value: String): Boolean = ULID_REGEX.matches(value.trim())
 
     companion object {
-        private val UUID_REGEX = Regex(
-            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-            RegexOption.IGNORE_CASE,
-        )
+        private val UUID_REGEX =
+            Regex(
+                "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                RegexOption.IGNORE_CASE,
+            )
 
-        private val ULID_REGEX = Regex(
-            "^[0-9A-HJ-NP-TV-Z]{26}$",
-            RegexOption.IGNORE_CASE,
-        )
+        private val ULID_REGEX =
+            Regex(
+                "^[0-9A-HJ-NP-TV-Z]{26}$",
+                RegexOption.IGNORE_CASE,
+            )
     }
 }

--- a/src/main/kotlin/features/uuid/subcommands/GenerateCommand.kt
+++ b/src/main/kotlin/features/uuid/subcommands/GenerateCommand.kt
@@ -1,0 +1,55 @@
+package org.jack.features.uuid.subcommands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.validate
+import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.int
+import org.jack.features.uuid.DEFAULT_UUID_COUNT
+import org.jack.features.uuid.UUID_COUNT_HELP
+import org.jack.features.uuid.UUID_COUNT_MUST_BE_POSITIVE_INTEGER
+import org.jack.features.uuid.UUID_COUNT_NAME
+import org.jack.features.uuid.UUID_COUNT_NAME_SHORT
+import org.jack.features.uuid.UUID_GENERATE_COMMAND_NAME
+import org.jack.features.uuid.UUID_GENERATE_HELP
+import org.jack.features.uuid.UUID_TYPE_HELP
+import org.jack.features.uuid.UUID_TYPE_NAME
+import org.jack.features.uuid.UUID_TYPE_NAME_SHORT
+import org.jack.features.uuid.UuidType
+import org.jack.features.uuid.services.UuidService
+
+class GenerateCommand(
+    private val uuidService: UuidService,
+) : CliktCommand(name = UUID_GENERATE_COMMAND_NAME) {
+    val count by option(
+        UUID_COUNT_NAME,
+        UUID_COUNT_NAME_SHORT,
+        help = UUID_COUNT_HELP,
+    ).int().default(DEFAULT_UUID_COUNT).validate {
+        require(it > 0) {
+            UUID_COUNT_MUST_BE_POSITIVE_INTEGER
+        }
+    }
+
+    val type: UuidType by option(
+        UUID_TYPE_NAME,
+        UUID_TYPE_NAME_SHORT,
+        help = UUID_TYPE_HELP,
+    ).enum<UuidType>().default(UuidType.UUID)
+
+    override fun help(context: Context) = UUID_GENERATE_HELP
+
+    override fun run() {
+        val getRandomId =
+            when (type) {
+                UuidType.UUID -> uuidService::randomUuid
+                UuidType.ULID -> uuidService::randomUlid
+            }
+
+        repeat(times = count) {
+            echo(getRandomId())
+        }
+    }
+}

--- a/src/main/kotlin/features/uuid/subcommands/ValidateCommand.kt
+++ b/src/main/kotlin/features/uuid/subcommands/ValidateCommand.kt
@@ -1,0 +1,45 @@
+package org.jack.features.uuid.subcommands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.enum
+import org.jack.features.uuid.UUID_TYPE_HELP
+import org.jack.features.uuid.UUID_TYPE_NAME
+import org.jack.features.uuid.UUID_TYPE_NAME_SHORT
+import org.jack.features.uuid.UUID_VALIDATE_COMMAND_NAME
+import org.jack.features.uuid.UUID_VALIDATE_HELP
+import org.jack.features.uuid.UUID_VALUE_ARGUMENT_NAME
+import org.jack.features.uuid.UUID_VALUE_HELP
+import org.jack.features.uuid.UuidType
+import org.jack.features.uuid.services.UuidService
+
+class ValidateCommand(
+    private val uuidService: UuidService,
+) : CliktCommand(name = UUID_VALIDATE_COMMAND_NAME) {
+    val value by argument(name = UUID_VALUE_ARGUMENT_NAME, help = UUID_VALUE_HELP)
+
+    val type: UuidType by option(
+        UUID_TYPE_NAME,
+        UUID_TYPE_NAME_SHORT,
+        help = UUID_TYPE_HELP,
+    ).enum<UuidType>().default(UuidType.UUID)
+
+    override fun help(context: Context) = UUID_VALIDATE_HELP
+
+    override fun run() {
+        val isValid =
+            when (type) {
+                UuidType.UUID -> uuidService.validateUuid(value)
+                UuidType.ULID -> uuidService.validateUlid(value)
+            }
+
+        if (isValid) {
+            echo("Status: Valid")
+        } else {
+            echo("Status: Invalid", err = true)
+        }
+    }
+}

--- a/src/test/kotlin/commands/UuidCommandTest.kt
+++ b/src/test/kotlin/commands/UuidCommandTest.kt
@@ -2,7 +2,6 @@ package commands
 
 import com.github.ajalt.clikt.testing.test
 import org.jack.features.uuid.UuidCommand
-import org.jack.features.uuid.UuidType
 import org.jack.features.uuid.services.impl.UuidServiceImpl
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -26,6 +25,20 @@ class UuidCommandTest {
     fun `when no arguments passed expect one uuid`() {
         val result = assertDoesNotThrow { command.test() }
 
+        assert(result.stdout.contains("Usage: uuid"))
+    }
+
+    @Test
+    fun `when generate subcommand with no arguments passed expect no error`() {
+        val result = assertDoesNotThrow { command.test("generate") }
+
+        assert(result.stderr.isEmpty())
+    }
+
+    @Test
+    fun `when generate subcommand with no arguments passed expect one uuid`() {
+        val result = assertDoesNotThrow { command.test("generate") }
+
         val uuidCount =
             result.stdout
                 .split("\n")
@@ -35,24 +48,24 @@ class UuidCommandTest {
     }
 
     @Test
-    fun `when '--count' argument passed with positive value expect no error`() {
-        val result = assertDoesNotThrow { command.test("--count 1") }
+    fun `when generate subcommand with '--count' argument passed with positive value expect no error`() {
+        val result = assertDoesNotThrow { command.test("generate --count 1") }
 
         assert(result.stderr.isEmpty())
     }
 
     @Test
-    fun `when '-c' argument passed with positive value expect no error`() {
-        val result = assertDoesNotThrow { command.test("-c 1") }
+    fun `when generate subcommand with '-c' argument passed with positive value expect no error`() {
+        val result = assertDoesNotThrow { command.test("generate -c 1") }
 
         assert(result.stderr.isEmpty())
     }
 
     @Test
-    fun `when '--count' argument passed with value 25 expect 25 uuids`() {
+    fun `when generate subcommand with '--count' argument passed with value 25 expect 25 uuids`() {
         val count = 25
 
-        val result = assertDoesNotThrow { command.test("--count $count") }
+        val result = assertDoesNotThrow { command.test("generate --count $count") }
 
         val uuidCount =
             result.stdout
@@ -63,45 +76,48 @@ class UuidCommandTest {
     }
 
     @Test
-    fun `when '--count' argument passed with negative value expect error`() {
-        val result = command.test("--count -1")
+    fun `when generate subcommand with '--count' argument passed with negative value expect error`() {
+        val result = command.test("generate --count -1")
 
         assert(result.stderr.isNotEmpty())
     }
 
     @Test
-    fun `when '-c' argument passed with negative value expect error`() {
-        val result = command.test("-c -1")
+    fun `when generate subcommand with '-c' argument passed with negative value expect error`() {
+        val result = command.test("generate -c -1")
 
         assert(result.stderr.isNotEmpty())
     }
 
     @Test
-    fun `when no '--type' argument passed 'type' member defaults to UUID`() {
-        val result = command.test().run { command }
+    fun `when generate subcommand with no '--type' argument passed expect UUID to be generated`() {
+        val result = command.test("generate").stdout
+        val trimmedResult = result.trim()
 
-        assert(result.type == UuidType.UUID)
+        assertDoesNotThrow { UUID.fromString(trimmedResult) }
     }
 
     @Test
-    fun `when '--type' argument passed with value 'uuid' type option is set to correct enum member`() {
-        val result = command.test("--type uuid").run { command }
+    fun `when generate subcommand with '--type' argument passed with value 'uuid' expect UUID to be generated`() {
+        val result = command.test("generate --type uuid").stdout
+        val trimmedResult = result.trim()
 
-        assert(result.type == UuidType.UUID)
+        assertDoesNotThrow { UUID.fromString(trimmedResult) }
     }
 
     @Test
-    fun `when '--type' argument passed with value 'ulid' type option is set to correct enum member`() {
-        val result = command.test("--type ulid").run { command }
+    fun `when generate subcommand with '--type' argument passed with value 'ulid' expect ULID to be generated`() {
+        val result = command.test("generate --type ulid").stdout
+        val trimmedResult = result.trim()
 
-        assert(result.type == UuidType.ULID)
+        assertDoesNotThrow { ULID.parseULID(trimmedResult) }
     }
 
     @Test
-    fun `when '--count' argument passed with value 25 expect 25 ulids`() {
+    fun `when generate subcommand with '--count' argument passed with value 25 expect 25 ulids`() {
         val count = 25
 
-        val result = assertDoesNotThrow { command.test("--type ulid --count $count") }
+        val result = assertDoesNotThrow { command.test("generate --type ulid --count $count") }
 
         val ulidCount =
             result.stdout
@@ -112,42 +128,26 @@ class UuidCommandTest {
     }
 
     @Test
-    fun `when '--type' argument passed with value 'uuid' expect a valid UUID`() {
-        val result = command.test("--type uuid").stdout
-        val trimmedResult = result.trim()
-
-        assertDoesNotThrow { UUID.fromString(trimmedResult) }
-    }
-
-    @Test
-    fun `when '--type' argument passed with value 'ulid' expect a valid ULID`() {
-        val result = command.test("--type ulid").stdout
-        val trimmedResult = result.trim()
-
-        assertDoesNotThrow { ULID.parseULID(trimmedResult) }
-    }
-
-    @Test
-    fun `validate valid uuid prints Status Valid`() {
-        val result = command.test("-v 3fa85f64-5717-4562-b3fc-2c963f66afa6")
+    fun `validate subcommand with valid uuid prints Status Valid`() {
+        val result = command.test("validate 3fa85f64-5717-4562-b3fc-2c963f66afa6")
         assertTrue(result.stdout.contains("Status: Valid"))
     }
 
     @Test
-    fun `validate invalid uuid prints Status Invalid`() {
-        val result = command.test("-v not-a-uuid-da")
+    fun `validate subcommand with invalid uuid prints Status Invalid`() {
+        val result = command.test("validate not-a-uuid-da")
         assertTrue(result.stderr.contains("Status: Invalid"))
     }
 
     @Test
-    fun `validate valid ulid prints Status Valid`() {
-        val result = command.test("--type ulid -v 01ARYZ6S41TSV4RRFFQ69G5FAV")
+    fun `validate subcommand with valid ulid prints Status Valid`() {
+        val result = command.test("validate --type ulid 01ARYZ6S41TSV4RRFFQ69G5FAV")
         assertTrue(result.stdout.contains("Status: Valid"))
     }
 
     @Test
-    fun `validate invalid ulid prints Status Invalid`() {
-        val result = command.test("--type ulid -v gibberish-thats-not-ulid-67")
+    fun `validate subcommand with invalid ulid prints Status Invalid`() {
+        val result = command.test("validate --type ulid gibberish-thats-not-ulid-67")
         assertTrue(result.stderr.contains("Status: Invalid"))
     }
 }

--- a/src/test/kotlin/commands/UuidCommandTest.kt
+++ b/src/test/kotlin/commands/UuidCommandTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import ulid.ULID
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class UuidCommandTest {
     private val uuidService = UuidServiceImpl()
@@ -124,5 +125,29 @@ class UuidCommandTest {
         val trimmedResult = result.trim()
 
         assertDoesNotThrow { ULID.parseULID(trimmedResult) }
+    }
+
+    @Test
+    fun `validate valid uuid prints Status Valid`() {
+        val result = command.test("-v 3fa85f64-5717-4562-b3fc-2c963f66afa6")
+        assertTrue(result.stdout.contains("Status: Valid"))
+    }
+
+    @Test
+    fun `validate invalid uuid prints Status Invalid`() {
+        val result = command.test("-v not-a-uuid-da")
+        assertTrue(result.stderr.contains("Status: Invalid"))
+    }
+
+    @Test
+    fun `validate valid ulid prints Status Valid`() {
+        val result = command.test("--type ulid -v 01ARYZ6S41TSV4RRFFQ69G5FAV")
+        assertTrue(result.stdout.contains("Status: Valid"))
+    }
+
+    @Test
+    fun `validate invalid ulid prints Status Invalid`() {
+        val result = command.test("--type ulid -v gibberish-thats-not-ulid-67")
+        assertTrue(result.stderr.contains("Status: Invalid"))
     }
 }


### PR DESCRIPTION
# Description

This PR adds UUID/ULID validation to the `jack uuid` command through a `--version` option after it, or alternatively the `-v` shorthand and thereafter specifying the UUID to be validated as described in the `README` docs under **UUIDs**.