### PR TITLE
docs: Add CI workflow statuses to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   <img src="https://img.shields.io/badge/Language-Kotlin-purple?logo=kotlin" alt="Kotlin">
   <img src="https://img.shields.io/badge/License-MIT-blueviolet" alt="MIT License">
   <img src="https://img.shields.io/badge/PRs-Welcome-mediumpurple" alt="PRs Welcome">
+  <img src="https://github.com/dimeskigj/jack-cli/actions/workflows/validation.yml/badge.svg" alt="Validation workflow status">
+  <img src="https://github.com/dimeskigj/jack-cli/actions/workflows/release.yml/badge.svg" alt="Release workflow status">
 </p>
 
 ## Usage


### PR DESCRIPTION
# Description

This PR adds badges to the README, conveying whether the (currently) active CI workflows on [main](https://github.com/dimeskigj/jack-cli/tree/main) are passing or not.

## Screenshots
### Before
<img width="866" height="372" alt="image" src="https://github.com/user-attachments/assets/9699eafd-8c28-4220-9d71-bc0a660d93ed" />

### After
<img width="838" height="398" alt="image" src="https://github.com/user-attachments/assets/71554c05-ee9c-4b81-91a0-879d813bb72a" />
